### PR TITLE
Bring Migrator into 2020

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.0.5.RELEASE'
+        springBootVersion = '2.2.6.RELEASE'
     }
     repositories {
         jcenter()
@@ -22,7 +22,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'jacoco'
     id 'org.sonarqube' version '2.5'
-    id 'org.springframework.boot' version '1.5.12.RELEASE'
+    id 'org.springframework.boot' version '2.2.6.RELEASE'
 }
 
 group = 'uk.gov.hmcts.reform.finrem.ccddatamigration'
@@ -66,12 +66,10 @@ def versions = [
         junit: '4.13',
         lombok: '1.16.18',
         reformLogging: '5.1.5',
-        reformSpringBootAutoConfigure: '1.1.0',
         restAssured: '3.0.3',
         serenity: '1.5.2',
         serenityCucumber: '1.1.3',
         serviceTokenGenerator: '1.0.0',
-        springfoxSwagger: '2.9.0',
         unirest: '1.4.9',
         wiremockVersion: '2.26.3'
 ]
@@ -82,8 +80,6 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: versions.commonsIo
     implementation group: 'io.github.openfeign', name: 'feign-httpclient', version: versions.feignHttpClient
     implementation group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
-    implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
-    implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
     implementation group: 'org.apache.commons', name: 'commons-lang3', version : versions.commonsLang3
     implementation group: 'org.springframework', name: 'spring-context-support'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
@@ -98,7 +94,6 @@ dependencies {
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-httpcomponents', version: versions.reformLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: versions.reformLogging
-    implementation group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: versions.reformSpringBootAutoConfigure
     implementation (group: 'uk.gov.hmcts.reform', name:'service-auth-provider-client', version: versions.serviceTokenGenerator)
             {
                 exclude group: 'io.reactivex', module: 'io.reactivex'

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,10 @@ plugins {
     id 'idea'
     id 'application'
     id 'checkstyle'
-    id 'com.github.ben-manes.versions' version '0.20.0'
+    id 'com.github.ben-manes.versions' version '0.28.0'
     id 'com.jfrog.bintray' version '1.8.0'
-    id 'info.solidsoft.pitest' version '1.3.0'
     id 'io.franzbecker.gradle-lombok' version '1.14'
-    id 'io.spring.dependency-management' version '1.0.5.RELEASE'
+    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'jacoco'
     id 'org.sonarqube' version '2.5'
     id 'org.springframework.boot' version '1.5.12.RELEASE'
@@ -63,38 +62,29 @@ def versions = [
         commonsLang3: '3.7',
         commonsIo: '2.5',
         feignHttpClient: '9.5.1',
-        gradlePitest: '1.3.0',
         jsonAssert: '1.2.3',
-        junit: '4.12',
+        junit: '4.13',
         lombok: '1.16.18',
-        pitest: '1.3.2',
-        puppyCrawl: '7.6',
         reformLogging: '5.1.5',
         reformSpringBootAutoConfigure: '1.1.0',
         restAssured: '3.0.3',
         serenity: '1.5.2',
         serenityCucumber: '1.1.3',
         serviceTokenGenerator: '1.0.0',
-        sonarPitest: '0.5',
         springfoxSwagger: '2.9.0',
         unirest: '1.4.9',
-        wiremockVersion: '2.18.0'
+        wiremockVersion: '2.26.3'
 ]
 
 dependencies {
     implementation('org.springframework.boot:spring-boot-starter-actuator')
     implementation('org.springframework.boot:spring-boot-starter-web')
-
     implementation group: 'commons-io', name: 'commons-io', version: versions.commonsIo
-    implementation group: 'com.puppycrawl.tools', name: 'checkstyle', version:  versions.puppyCrawl
-    implementation group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: versions.gradlePitest
     implementation group: 'io.github.openfeign', name: 'feign-httpclient', version: versions.feignHttpClient
     implementation group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
     implementation group: 'org.apache.commons', name: 'commons-lang3', version : versions.commonsLang3
-    implementation group: 'org.codehaus.sonar-plugins', name:'sonar-pitest-plugin', version: versions.sonarPitest
-    implementation group: 'org.pitest', name: 'pitest', version: versions.pitest
     implementation group: 'org.springframework', name: 'spring-context-support'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
     implementation (group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign')

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,8 @@ buildscript {
         springBootVersion = '2.0.5.RELEASE'
     }
     repositories {
-        mavenLocal()
         jcenter()
-
+        mavenLocal()
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
@@ -20,11 +19,11 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'com.jfrog.bintray' version '1.8.0'
     id 'info.solidsoft.pitest' version '1.3.0'
+    id 'io.franzbecker.gradle-lombok' version '1.14'
     id 'io.spring.dependency-management' version '1.0.5.RELEASE'
     id 'jacoco'
     id 'org.sonarqube' version '2.5'
     id 'org.springframework.boot' version '1.5.12.RELEASE'
-    id 'pmd'
 }
 
 group = 'uk.gov.hmcts.reform.finrem.ccddatamigration'
@@ -43,12 +42,10 @@ compileTestJava {
 }
 
 repositories {
-    mavenLocal()
     jcenter()
-
+    mavenLocal()
     maven { url 'https://repo.spring.io/libs-milestone' }
     maven { url "https://dl.bintray.com/hmcts/hmcts-maven" }
-    maven { url "http://repo.maven.apache.org/maven2" }
 }
 
 distributions {
@@ -69,10 +66,10 @@ def versions = [
         gradlePitest: '1.3.0',
         jsonAssert: '1.2.3',
         junit: '4.12',
-        lombok: '1.16.16',
+        lombok: '1.16.18',
         pitest: '1.3.2',
         puppyCrawl: '7.6',
-        reformsJavaLogging: '3.0.1',
+        reformLogging: '5.1.5',
         reformSpringBootAutoConfigure: '1.1.0',
         restAssured: '3.0.3',
         serenity: '1.5.2',
@@ -85,39 +82,41 @@ def versions = [
 ]
 
 dependencies {
-    compile('org.springframework.boot:spring-boot-starter-actuator')
-    compile('org.springframework.boot:spring-boot-starter-web')
+    implementation('org.springframework.boot:spring-boot-starter-actuator')
+    implementation('org.springframework.boot:spring-boot-starter-web')
 
-    compile group: 'commons-io', name: 'commons-io', version: versions.commonsIo
-    compile group: 'com.puppycrawl.tools', name: 'checkstyle', version:  versions.puppyCrawl
-    compile group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: versions.gradlePitest
-    compile group: 'io.github.openfeign', name: 'feign-httpclient', version: versions.feignHttpClient
-    compile group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
-    compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
-    compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
-    compile group: 'org.apache.commons', name: 'commons-lang3', version : versions.commonsLang3
-    compile group: 'org.codehaus.sonar-plugins', name:'sonar-pitest-plugin', version: versions.sonarPitest
-    compile group: 'org.pitest', name: 'pitest', version: versions.pitest
-    compile group: 'org.springframework', name: 'spring-context-support'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-json'
-    compile (group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign')
+    implementation group: 'commons-io', name: 'commons-io', version: versions.commonsIo
+    implementation group: 'com.puppycrawl.tools', name: 'checkstyle', version:  versions.puppyCrawl
+    implementation group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: versions.gradlePitest
+    implementation group: 'io.github.openfeign', name: 'feign-httpclient', version: versions.feignHttpClient
+    implementation group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
+    implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
+    implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version : versions.commonsLang3
+    implementation group: 'org.codehaus.sonar-plugins', name:'sonar-pitest-plugin', version: versions.sonarPitest
+    implementation group: 'org.pitest', name: 'pitest', version: versions.pitest
+    implementation group: 'org.springframework', name: 'spring-context-support'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
+    implementation (group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign')
             {
                 exclude group: 'io.reactivex', module: 'io.reactivex'
                 exclude group: 'io.reactivex', module: 'rxnetty'
                 exclude group: 'io.reactivex', module: 'rxnetty-contexts'
                 exclude group: 'io.reactivex', module: 'rxnetty-servo'
             }
-    compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformsJavaLogging
-    compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: versions.reformsJavaLogging
-    compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: versions.reformSpringBootAutoConfigure
-    compile (group: 'uk.gov.hmcts.reform', name:'service-auth-provider-client', version: versions.serviceTokenGenerator)
+    implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
+    implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
+    implementation group: 'uk.gov.hmcts.reform', name: 'logging-httpcomponents', version: versions.reformLogging
+    implementation group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: versions.reformLogging
+    implementation group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: versions.reformSpringBootAutoConfigure
+    implementation (group: 'uk.gov.hmcts.reform', name:'service-auth-provider-client', version: versions.serviceTokenGenerator)
             {
                 exclude group: 'io.reactivex', module: 'io.reactivex'
                 exclude group: 'io.reactivex', module: 'rxnetty'
                 exclude group: 'io.reactivex', module: 'rxnetty-contexts'
                 exclude group: 'io.reactivex', module: 'rxnetty-servo'
             }
-    compile (group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: versions.ccdStoreClient)
+    implementation (group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: versions.ccdStoreClient)
             {
                 exclude group: 'io.reactivex', module: 'io.reactivex'
                 exclude group: 'io.reactivex', module: 'rxnetty'
@@ -126,9 +125,8 @@ dependencies {
             }
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
-    testCompile group: 'com.github.tomakehurst', name:'wiremock', version: versions.wiremockVersion
-    testCompile('org.springframework.boot:spring-boot-starter-test')
-    runtime('org.springframework.boot:spring-boot-devtools')
+    testImplementation group: 'com.github.tomakehurst', name:'wiremock', version: versions.wiremockVersion
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 
 checkstyle.toolVersion = '8.32'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip

--- a/src/main/java/uk/gov/hmcts/reform/finrem/ccddatamigration/processor/DataMigrationProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/ccddatamigration/processor/DataMigrationProcessor.java
@@ -67,24 +67,20 @@ public class DataMigrationProcessor implements CommandLineRunner {
                 log.info("Start processing cases");
             }
             final String userToken = idamClient.generateUserTokenWithNoRoles(idamUserName, idamUserPassword);
-            if (debugEnabled) {
-                log.info("  userToken  : {}", userToken);
-            }
             final String s2sToken = authTokenGenerator.generate();
-            if (debugEnabled) {
-                log.info("  s2sToken : {}", s2sToken);
-            }
             final String userId = idamUserService.retrieveUserDetails(userToken).getId();
             if (debugEnabled) {
+                log.info("  userToken  : {}", userToken);
+                log.info("  s2sToken : {}", s2sToken);
                 log.info("  userId  : {}", userId);
             }
             log.info("Case Id {}", ccdCaseId);
 
             if (isNotBlank(ccdCaseId)) {
-                log.info("migrate single case, caseId  {}", ccdCaseId);
+                log.info("Migrate single case with Case ID: {}", ccdCaseId);
                 migrationService.processSingleCase(userToken, s2sToken, ccdCaseId);
             } else {
-                log.info("migrate multiple cases .....");
+                log.info("Migrate multiple cases .....");
                 caseTypes.forEach(caseType -> {
                     log.info("migrate caseType ....." + caseType);
                     migrationService.processAllTheCases(userToken, s2sToken, userId, jurisdictionId, caseType);
@@ -99,7 +95,7 @@ public class DataMigrationProcessor implements CommandLineRunner {
             log.info("Total number of cases: " + migrationService.getTotalNumberOfCases());
             log.info("Total migrations performed: " + migrationService.getTotalMigrationsPerformed());
             log.info("-----------------------------");
-            log.info("Failed Cases {}",
+            log.info("Failed Cases: {}",
                     isNotBlank(migrationService.getFailedCases()) ? migrationService.getFailedCases() : "NONE");
 
         } catch (final Throwable e) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/ccddatamigration/service/GeneralMigrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/ccddatamigration/service/GeneralMigrationService.java
@@ -54,7 +54,7 @@ public class GeneralMigrationService implements MigrationService {
                 log.info("Case {} doesn't meet migration criteria", aCase.getId());
             }
         } catch (final Exception ex) {
-            log.error("case {} not found, {}", ccdCaseId, ex.getMessage());
+            log.error("Case {} not found, {}", ccdCaseId, ex.getMessage());
         }
     }
 
@@ -66,10 +66,10 @@ public class GeneralMigrationService implements MigrationService {
         log.info("Number of pages : {}", numberOfPages);
 
         if (dryRun) {
-            log.info("caseType {}  and dryRun for one case ...", caseType);
+            log.info("caseType {} and dryRun for one case ...", caseType);
             dryRunWithOneCase(userToken, s2sToken, userId, jurisdictionId, caseType, numberOfPages);
         } else {
-            log.info("migrating all the cases ...");
+            log.info("Migrating all the cases ...");
             IntStream.rangeClosed(1, numberOfPages)
                     .forEach(pageNumber -> migrateCasesForPage(userToken, s2sToken, userId, jurisdictionId, caseType, pageNumber));
         }
@@ -135,7 +135,7 @@ public class GeneralMigrationService implements MigrationService {
                 caseType,
                 searchCriteria);
         if (debugEnabled) {
-            log.debug("Pagination>>" + paginationInfoForSearchForCaseworkers.toString());
+            log.debug("Pagination>> " + paginationInfoForSearchForCaseworkers.toString());
         }
         return paginationInfoForSearchForCaseworkers.getTotalPagesCount();
     }
@@ -184,7 +184,7 @@ public class GeneralMigrationService implements MigrationService {
         totalNumberOfCases++;
         final String caseId = caseDetails.getId().toString();
         if (debugEnabled) {
-            log.info("updating case with id :" + caseId);
+            log.info("Updating case with Case ID:" + caseId);
         }
         try {
             updateCase(authorisation, caseDetails, caseType);
@@ -193,7 +193,7 @@ public class GeneralMigrationService implements MigrationService {
             }
             updateMigratedCases(caseDetails.getId());
         } catch (final Exception e) {
-            log.error("update failed for case with id [{}] with error [{}] ", caseDetails.getId().toString(), e.getMessage());
+            log.error("Update failed for Case ID [{}] with error [{}] ", caseDetails.getId().toString(), e.getMessage());
             updateFailedCases(caseDetails.getId());
         }
     }


### PR DESCRIPTION
- Bump Gradle Wrapper from 4.5.1 to 6.5.1
- Bumped SpringBoot from '2.0.5.RELEASE' to '2.2.6.RELEASE'
- Removed redundant dependencies like Swagger, PiTest and deprecated HMCTS Logging tools