### PR TITLE
Bumped to Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,17 +18,17 @@ plugins {
     id 'checkstyle'
     id 'com.github.ben-manes.versions' version '0.28.0'
     id 'com.jfrog.bintray' version '1.8.0'
-    id 'io.franzbecker.gradle-lombok' version '1.14'
+    id 'io.franzbecker.gradle-lombok' version '4.0.0'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'jacoco'
-    id 'org.sonarqube' version '2.5'
+    id 'org.sonarqube' version '3.0'
     id 'org.springframework.boot' version '2.2.6.RELEASE'
 }
 
 group = 'uk.gov.hmcts.reform.finrem.ccddatamigration'
 version = '1.0.0'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 
 mainClassName = 'uk.gov.hmcts.reform.finrem.ccddatamigration.CcdDataMigrationApplication'
 
@@ -59,19 +59,19 @@ distributions {
 
 def versions = [
         ccdStoreClient: '4.4.1',
-        commonsLang3: '3.7',
-        commonsIo: '2.5',
+        commonsLang3: '3.10',
+        commonsIo: '2.7',
         feignHttpClient: '9.5.1',
         jsonAssert: '1.2.3',
         junit: '4.13',
-        lombok: '1.16.18',
-        reformLogging: '5.1.5',
+        lombok: '1.18.12',
+        reformLogging: '5.1.6',
         restAssured: '3.0.3',
-        serenity: '1.5.2',
-        serenityCucumber: '1.1.3',
+        serenity: '2.2.10',
+        serenityCucumber: '1.9.51',
         serviceTokenGenerator: '1.0.0',
         unirest: '1.4.9',
-        wiremockVersion: '2.26.3'
+        wiremockVersion: '2.27.1'
 ]
 
 dependencies {


### PR DESCRIPTION
- Update to Java 11 from Java 8

Ran dry run against AAT to prove migration tool still works as expected:

_"2020-Jul-10 12:25:36 INFO  ? - The following profiles are active: aat
""2020-Jul-10 12:25:41 INFO  ? - Started CcdDataMigrationApplication in 8.493 seconds (JVM running for 12.189)
""2020-Jul-10 12:25:45 INFO  ? - Case Id 
""2020-Jul-10 12:25:45 INFO  ? - Migrate multiple cases .....
""2020-Jul-10 12:25:45 INFO  ? - migrate caseType .....FinancialRemedyMVP2
""2020-Jul-10 12:25:46 INFO  ? - Number of pages : 134
""2020-Jul-10 12:25:46 INFO  ? - caseType FinancialRemedyMVP2 and dryRun for one case ...
""2020-Jul-10 12:29:12 INFO  ? - migrate caseType .....FinancialRemedyContested
""2020-Jul-10 12:29:12 INFO  ? - Number of pages : 103
""2020-Jul-10 12:29:12 INFO  ? - caseType FinancialRemedyContested and dryRun for one case ...
""2020-Jul-10 12:29:47 INFO  ? - Migrated Cases NONE 
""2020-Jul-10 12:29:47 INFO  ? - -----------------------------
""2020-Jul-10 12:29:47 INFO  ? - Data migration completed
""2020-Jul-10 12:29:47 INFO  ? - -----------------------------
""2020-Jul-10 12:29:47 INFO  ? - Total number of cases: 0
""2020-Jul-10 12:29:47 INFO  ? - Total migrations performed: 0
""2020-Jul-10 12:29:47 INFO  ? - -----------------------------
""2020-Jul-10 12:29:47 INFO  ? - Failed Cases: NONE_
