### PR TITLE
Improve CCD Data migration functionality

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/ccddatamigration/service/CommonFunction.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/ccddatamigration/service/CommonFunction.java
@@ -25,14 +25,13 @@ public class CommonFunction {
         return CASE_TYPE_ID_CONSENTED.equalsIgnoreCase(nullToEmpty(caseDetails.getCaseTypeId()));
     }
 
-    public static boolean isCaseInCorrectState(CaseDetails caseDetails, String expectedState) {
-
-        return expectedState.equalsIgnoreCase(nullToEmpty(caseDetails.getState()));
-    }
-
-    public static boolean isCaseInCorrectState(CaseDetails caseDetails, String expectedState1, String expectedState2) {
-
-        return expectedState1.equalsIgnoreCase(nullToEmpty(caseDetails.getState()))
-            || expectedState2.equalsIgnoreCase(nullToEmpty(caseDetails.getState()));
+    // Will handle any amount of states passed in as comma separated strings - "consentOrderMade", "awaitingResponse", "..."
+    public static boolean isCaseInCorrectState(CaseDetails caseDetails, String... states) {
+        for (String state : states) {
+            if (state.equalsIgnoreCase(nullToEmpty(caseDetails.getState()))) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/ccddatamigration/service/CommonFunction.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/ccddatamigration/service/CommonFunction.java
@@ -29,4 +29,10 @@ public class CommonFunction {
 
         return expectedState.equalsIgnoreCase(nullToEmpty(caseDetails.getState()));
     }
+
+    public static boolean isCaseInCorrectState(CaseDetails caseDetails, String expectedState1, String expectedState2) {
+
+        return expectedState1.equalsIgnoreCase(nullToEmpty(caseDetails.getState()))
+            || expectedState2.equalsIgnoreCase(nullToEmpty(caseDetails.getState()));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/ccddatamigration/service/CommonFunctionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/ccddatamigration/service/CommonFunctionTest.java
@@ -62,42 +62,42 @@ public class CommonFunctionTest {
     }
 
     @Test
-    public void isInCorrectCaseStateShouldReturnTrueWhenCaseIsInExpectedState() {
+    public void isInCorrectCaseStateShouldReturnTrueWhenStateIsInExpectedState() {
         CaseDetails caseDetails = createCaseDetails(CASE_TYPE_ID_CONSENTED, "expectedState");
 
         assertThat(isCaseInCorrectState(caseDetails, "expectedState"), is(true));
     }
 
     @Test
-    public void isInCorrectCaseStateShouldReturnFalseWhenCaseIsInUnexpectedState() {
+    public void isInCorrectCaseStateShouldReturnFalseWhenStateIsInUnexpectedState() {
         CaseDetails caseDetails = createCaseDetails(CASE_TYPE_ID_CONSENTED, "expectedState");
 
         assertThat(isCaseInCorrectState(caseDetails, "unexpectedState"), is(false));
     }
 
     @Test
-    public void isInCorrectCaseStateShouldReturnFalseWhenCaseIsNull() {
+    public void isInCorrectCaseStateShouldReturnFalseWhenStateIsNull() {
         CaseDetails caseDetails = createCaseDetails(CASE_TYPE_ID_CONSENTED, null);
 
         assertThat(isCaseInCorrectState(caseDetails, "expectedState"), is(false));
     }
 
     @Test
-    public void isInCorrectCaseStateShouldReturnTrueWhenCaseIsInEitherExpectedState() {
+    public void isInCorrectCaseStateShouldReturnTrueWhenMultipleStatesAreProvidedAndOneIsInExpectedState() {
         CaseDetails caseDetails = createCaseDetails(CASE_TYPE_ID_CONSENTED, "expectedState");
 
-        assertThat(isCaseInCorrectState(caseDetails, "expectedState", "redundantSecondState"), is(true));
+        assertThat(isCaseInCorrectState(caseDetails, "expectedState", "redundantSecondState", "redundantThirdState"), is(true));
     }
 
     @Test
-    public void isInCorrectCaseStateShouldReturnTrueWhenCaseIsInOneExpectedStateAndOtherIsNull() {
+    public void isInCorrectCaseStateShouldReturnTrueWhenMultipleStatesAreProvidedAndOneIsInExpectedStateAndOtherIsNull() {
         CaseDetails caseDetails = createCaseDetails(CASE_TYPE_ID_CONSENTED, "expectedState");
 
         assertThat(isCaseInCorrectState(caseDetails, "expectedState", null), is(true));
     }
 
     @Test
-    public void isInCorrectCaseStateShouldReturnFalseWhenCaseIsInNeitherExpectedState() {
+    public void isInCorrectCaseStateShouldReturnFalseWhenMultipleStatesAreProvidedAndNoneAreInExpectedState() {
         CaseDetails caseDetails = createCaseDetails(CASE_TYPE_ID_CONSENTED, "expectedState");
 
         assertThat(isCaseInCorrectState(caseDetails, "unexpectedState", "unexpectedState2"), is(false));

--- a/src/test/java/uk/gov/hmcts/reform/finrem/ccddatamigration/service/CommonFunctionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/ccddatamigration/service/CommonFunctionTest.java
@@ -19,7 +19,6 @@ import static uk.gov.hmcts.reform.finrem.ccddatamigration.service.CommonFunction
 @RunWith(MockitoJUnitRunner.class)
 public class CommonFunctionTest {
 
-
     @Test
     public void isConsentedCaseShouldReturnTrueWheCaseTypeIsSetToConsentedCaseType() {
         CaseDetails caseDetails = createCaseDetails(CASE_TYPE_ID_CONSENTED, "expectedState");
@@ -81,6 +80,27 @@ public class CommonFunctionTest {
         CaseDetails caseDetails = createCaseDetails(CASE_TYPE_ID_CONSENTED, null);
 
         assertThat(isCaseInCorrectState(caseDetails, "expectedState"), is(false));
+    }
+
+    @Test
+    public void isInCorrectCaseStateShouldReturnTrueWhenCaseIsInEitherExpectedState() {
+        CaseDetails caseDetails = createCaseDetails(CASE_TYPE_ID_CONSENTED, "expectedState");
+
+        assertThat(isCaseInCorrectState(caseDetails, "expectedState", "redundantSecondState"), is(true));
+    }
+
+    @Test
+    public void isInCorrectCaseStateShouldReturnTrueWhenCaseIsInOneExpectedStateAndOtherIsNull() {
+        CaseDetails caseDetails = createCaseDetails(CASE_TYPE_ID_CONSENTED, "expectedState");
+
+        assertThat(isCaseInCorrectState(caseDetails, "expectedState", null), is(true));
+    }
+
+    @Test
+    public void isInCorrectCaseStateShouldReturnFalseWhenCaseIsInNeitherExpectedState() {
+        CaseDetails caseDetails = createCaseDetails(CASE_TYPE_ID_CONSENTED, "expectedState");
+
+        assertThat(isCaseInCorrectState(caseDetails, "unexpectedState", "unexpectedState2"), is(false));
     }
 
     private CaseDetails createCaseDetails(String caseType, String state) {


### PR DESCRIPTION
- Added overloaded method for isCaseInCorrectState for handling multiple states at same time
- Cleaned up logic around running specific event for cases rather than 'FR_Migration' event